### PR TITLE
Add the engines key to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 2. Open the workspace on Gitpod using the green Gitpod button 
 3. In ther terminal enter the following command:   
 `npx create-react-app . --template git+https://github.com/Code-Institute-Org/cra-template-moments.git --use-npm`
-4. Enter `y` to confirm installing the creat-react-app package
-4. Start the app with:   
+4. Enter `y` to confirm installing the create-react-app package
+5. Start the app with:   
 `npm start`
 

--- a/template/package.json
+++ b/template/package.json
@@ -44,5 +44,9 @@
   },
   "devDependencies": {
     "msw": "^0.35.0"
+  },
+  "engines": {
+    "node": "16.19.1",
+    "npm": "8.19.3"
   }
 }


### PR DESCRIPTION
Heroku requires that the node and npm version are specified in the package.json. 